### PR TITLE
Allow fractional font sizing in slider

### DIFF
--- a/lib/screens/slider_screen.dart
+++ b/lib/screens/slider_screen.dart
@@ -134,6 +134,7 @@ class _SliderScreenState extends ConsumerState<SliderScreen> {
                   maxLines: 3,
                   minFontSize: screenHeight * 0.035 * textScale,
                   maxFontSize: screenHeight * 0.06 * textScale,
+                  stepGranularity: 0.1,
                   style: TextStyle(
                     color: const Color(0xFF112D4E),
                     fontFamily: 'Poppins',


### PR DESCRIPTION
## Summary
- allow fractional font sizes in `AutoSizeText`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e1abe3a883338818f887baefbd24