### PR TITLE
Allow fractional font sizing in slider

### DIFF
--- a/lib/screens/slider_screen.dart
+++ b/lib/screens/slider_screen.dart
@@ -132,7 +132,7 @@ class _SliderScreenState extends ConsumerState<SliderScreen> {
                   _slideTexts[_currentPage],
                   textAlign: TextAlign.center,
                   maxLines: 3,
-                  minFontSize: screenHeight * 0.035 * textScale,
+                  minFontSize: (screenHeight * 0.035 * textScale).roundToDouble(),
                   maxFontSize: screenHeight * 0.06 * textScale,
                   style: TextStyle(
                     color: const Color(0xFF112D4E),


### PR DESCRIPTION
## Summary
- allow fractional font sizes in `AutoSizeText`
- round `minFontSize` to avoid assertion

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e1abe3a883338818f887baefbd24