### PR TITLE
Allow fractional font sizing in slider

### DIFF
--- a/lib/screens/slider_screen.dart
+++ b/lib/screens/slider_screen.dart
@@ -93,9 +93,11 @@ class _SliderScreenState extends ConsumerState<SliderScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final screenHeight = Responsive.screenHeight(context);
+    final mediaQuery = MediaQuery.of(context);
+    final screenHeight =
+        Responsive.screenHeight(context) - mediaQuery.padding.vertical;
     final screenWidth = Responsive.screenWidth(context);
-    final textScale = MediaQuery.of(context).textScaleFactor;
+    final textScale = mediaQuery.textScaleFactor;
 
     return Scaffold(
       backgroundColor: const Color(0xFFF9F7F7),
@@ -132,7 +134,7 @@ class _SliderScreenState extends ConsumerState<SliderScreen> {
                   _slideTexts[_currentPage],
                   textAlign: TextAlign.center,
                   maxLines: 3,
-                  minFontSize: screenHeight * 0.035 * textScale,
+                  minFontSize: (screenHeight * 0.035 * textScale).roundToDouble(),
                   maxFontSize: screenHeight * 0.06 * textScale,
                   style: TextStyle(
                     color: const Color(0xFF112D4E),
@@ -147,7 +149,7 @@ class _SliderScreenState extends ConsumerState<SliderScreen> {
                 _buildDotIndicator(),
             
                 SizedBox(
-                  height: Responsive.screenHeight(context) * 0.07,
+                  height: screenHeight * 0.07,
                 ), // spacing between dots and button
                 Padding(
                   padding:  EdgeInsets.symmetric(horizontal: screenWidth * .07),


### PR DESCRIPTION
## Summary
- allow fractional font sizes in `AutoSizeText`
- round `minFontSize` to avoid assertion
- fix column overflow by subtracting safe area height

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e1abe3a883338818f887baefbd24