### PR TITLE
Fix horizontal list item overflow

### DIFF
--- a/lib/widgets/horizontal_card_list.dart
+++ b/lib/widgets/horizontal_card_list.dart
@@ -9,7 +9,8 @@ class HorizontalCardList extends StatelessWidget {
     final screenWidth = MediaQuery.of(context).size.width;
     final cardWidth = screenWidth * 0.55;
     final imageSize = cardWidth;
-    final cardHeight = cardWidth + screenWidth * 0.15;
+    // Extra space below the image prevents overflow on smaller screens.
+    final cardHeight = cardWidth + screenWidth * 0.17;
     final spacing = screenWidth * 0.03;
     final smallPadding = screenWidth * 0.02;
 


### PR DESCRIPTION
## Summary
- increase `HorizontalCardList` height spacing to avoid overflow issues

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6856ec4421fc8333b54162f1daafdf76